### PR TITLE
Present survey on the application's view controller

### DIFF
--- a/Iterate.xcodeproj/project.pbxproj
+++ b/Iterate.xcodeproj/project.pbxproj
@@ -18,6 +18,10 @@
 		270613E623BA4F2500DDF342 /* Survey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270613E523BA4F2500DDF342 /* Survey.swift */; };
 		270613EB23BA6BFD00DDF342 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270613EA23BA6BFD00DDF342 /* Client.swift */; };
 		270613EF23BA6F6A00DDF342 /* Embed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270613EE23BA6F6A00DDF342 /* Embed.swift */; };
+		27063AB024980D2B00BE6913 /* DisplayedEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27063AAF24980D2B00BE6913 /* DisplayedEndpoint.swift */; };
+		27063AB524980D3F00BE6913 /* DismissedEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27063AB424980D3F00BE6913 /* DismissedEndpoint.swift */; };
+		27063AB72498108900BE6913 /* Displayed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27063AB62498108900BE6913 /* Displayed.swift */; };
+		27063AB92498109700BE6913 /* Dismissed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27063AB82498109700BE6913 /* Dismissed.swift */; };
 		2757AB5B248EDDFE00B909C9 /* PromptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2757AB5A248EDDFE00B909C9 /* PromptViewController.swift */; };
 		2757AB60248FC4FE00B909C9 /* ContainerWindowDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2757AB5F248FC4FE00B909C9 /* ContainerWindowDelegate.swift */; };
 		27821A3C24900C08004AAB22 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27821A3B24900C08004AAB22 /* Color.swift */; };
@@ -87,6 +91,10 @@
 		270613E523BA4F2500DDF342 /* Survey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.swift; sourceTree = "<group>"; };
 		270613EA23BA6BFD00DDF342 /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
 		270613EE23BA6F6A00DDF342 /* Embed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Embed.swift; sourceTree = "<group>"; };
+		27063AAF24980D2B00BE6913 /* DisplayedEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayedEndpoint.swift; sourceTree = "<group>"; };
+		27063AB424980D3F00BE6913 /* DismissedEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissedEndpoint.swift; sourceTree = "<group>"; };
+		27063AB62498108900BE6913 /* Displayed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Displayed.swift; sourceTree = "<group>"; };
+		27063AB82498109700BE6913 /* Dismissed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dismissed.swift; sourceTree = "<group>"; };
 		2757AB5A248EDDFE00B909C9 /* PromptViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptViewController.swift; sourceTree = "<group>"; };
 		2757AB5F248FC4FE00B909C9 /* ContainerWindowDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerWindowDelegate.swift; sourceTree = "<group>"; };
 		27821A3B24900C08004AAB22 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
@@ -213,6 +221,8 @@
 				270613EE23BA6F6A00DDF342 /* Embed.swift */,
 				270613E523BA4F2500DDF342 /* Survey.swift */,
 				27C3B28723BAA4BD00754F4D /* Response.swift */,
+				27063AB62498108900BE6913 /* Displayed.swift */,
+				27063AB82498109700BE6913 /* Dismissed.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -297,6 +307,8 @@
 			isa = PBXGroup;
 			children = (
 				27C3B28523BAA3A900754F4D /* EmbedEndpoint.swift */,
+				27063AAF24980D2B00BE6913 /* DisplayedEndpoint.swift */,
+				27063AB424980D3F00BE6913 /* DismissedEndpoint.swift */,
 			);
 			path = Endpoints;
 			sourceTree = "<group>";
@@ -557,9 +569,12 @@
 				270613EB23BA6BFD00DDF342 /* Client.swift in Sources */,
 				270613E023BA4DD100DDF342 /* Errors.swift in Sources */,
 				27C3B28A23BCF5FC00754F4D /* Context.swift in Sources */,
+				27063AB92498109700BE6913 /* Dismissed.swift in Sources */,
+				27063AB72498108900BE6913 /* Displayed.swift in Sources */,
 				27C3B29723BD354C00754F4D /* Storage.swift in Sources */,
 				27C3B2F123BFDECF00754F4D /* ContainerViewController.swift in Sources */,
 				27C3B28823BAA4BD00754F4D /* Response.swift in Sources */,
+				27063AB524980D3F00BE6913 /* DismissedEndpoint.swift in Sources */,
 				27AEEEA7245DB3F800351EC1 /* SendEvent.swift in Sources */,
 				27C3B28623BAA3A900754F4D /* EmbedEndpoint.swift in Sources */,
 				270613EF23BA6F6A00DDF342 /* Embed.swift in Sources */,
@@ -568,6 +583,7 @@
 				27DDDD5323C657F4005CA07C /* SurveyViewController.swift in Sources */,
 				27C3B2F323C399B200754F4D /* ContainerView.swift in Sources */,
 				27C3B28223BA9BB600754F4D /* Paths.swift in Sources */,
+				27063AB024980D2B00BE6913 /* DisplayedEndpoint.swift in Sources */,
 				270613D823AD8D6200DDF342 /* Iterate.swift in Sources */,
 				27C3B2EF23BFD44400754F4D /* ContainerWindow.swift in Sources */,
 			);

--- a/Iterate/API/Client.swift
+++ b/Iterate/API/Client.swift
@@ -48,15 +48,15 @@ class APIClient {
     ///   - path: Path to call
     ///   - data: Post body data
     ///   - complete: Results callback
-    func post<T: Codable> (path: Path, data: Data, complete: @escaping (T?, Error?) -> Void) {
-        guard var request = request(path: Paths.Surveys.Embed) else {
+    func post<T: Codable> (path: Path, data: Data?, complete: @escaping (T?, Error?) -> Void) {
+        guard var request = request(path: path) else {
             complete(nil, IterateError.invalidAPIUrl)
             return
         }
         
         request.httpMethod = "POST"
         request.httpBody = data
-        
+
         dataTask(request: request, complete: complete)
     }
     

--- a/Iterate/API/Endpoints/DismissedEndpoint.swift
+++ b/Iterate/API/Endpoints/DismissedEndpoint.swift
@@ -1,0 +1,15 @@
+//
+//  DismissedEndpoint.swift
+//  Iterate
+//
+//  Created by Michael Singleton on 6/15/20.
+//  Copyright © 2020 Pickaxe LLC. (DBA Iterate). All rights reserved.
+//
+
+import Foundation
+
+extension APIClient {
+    func dismissed(survey: Survey, complete: @escaping (Dismissed?, Error?) -> Void) {
+        post(path: Paths.Surveys.Dismissed(surveyId: survey.id), data: nil, complete: complete)
+    }
+}

--- a/Iterate/API/Endpoints/DisplayedEndpoint.swift
+++ b/Iterate/API/Endpoints/DisplayedEndpoint.swift
@@ -1,0 +1,15 @@
+//
+//  DisplayedEndpoint.swift
+//  Iterate
+//
+//  Created by Michael Singleton on 6/15/20.
+//  Copyright © 2020 Pickaxe LLC. (DBA Iterate). All rights reserved.
+//
+
+import Foundation
+
+extension APIClient {
+    func displayed(survey: Survey, complete: @escaping (Displayed?, Error?) -> Void) {
+        post(path: Paths.Surveys.Displayed(surveyId: survey.id), data: nil, complete: complete)
+    }
+}

--- a/Iterate/API/Endpoints/EmbedEndpoint.swift
+++ b/Iterate/API/Endpoints/EmbedEndpoint.swift
@@ -25,7 +25,7 @@ extension APIClient {
     /// Embed API endpoint
     /// - Parameter context: Contains all data about the context of the embed call (device type, triggers, etc)
     /// - Parameter complete: Results callback
-    func embed(context: EmbedContext, complete: @escaping (EmbedResponse?, Error?) -> Void) -> Void {
+    func embed(context: EmbedContext, complete: @escaping (EmbedResponse?, Error?) -> Void) {
         guard let data = try? encoder.encode(context) else {
             complete(nil, IterateError.jsonEncoding)
             return

--- a/Iterate/API/Models/Dismissed.swift
+++ b/Iterate/API/Models/Dismissed.swift
@@ -1,0 +1,16 @@
+//
+//  Dismissed.swift
+//  Iterate
+//
+//  Created by Michael Singleton on 6/15/20.
+//  Copyright © 2020 Pickaxe LLC. (DBA Iterate). All rights reserved.
+//
+
+import Foundation
+
+public struct Dismissed: Codable {
+    let id: String
+    let lastDismissed: String
+    let surveyId: String
+    let userId: String
+}

--- a/Iterate/API/Models/Displayed.swift
+++ b/Iterate/API/Models/Displayed.swift
@@ -1,0 +1,16 @@
+//
+//  Displayed.swift
+//  Iterate
+//
+//  Created by Michael Singleton on 6/15/20.
+//  Copyright © 2020 Pickaxe LLC. (DBA Iterate). All rights reserved.
+//
+
+import Foundation
+
+public struct Displayed: Codable {
+    let id: String
+    let lastDisplayed: String
+    let surveyId: String
+    let userId: String
+}

--- a/Iterate/API/Paths.swift
+++ b/Iterate/API/Paths.swift
@@ -18,5 +18,7 @@ struct Paths {
 
 /// Survey-level API paths
 struct SurveyPaths {
+    func Displayed(surveyId: String) -> Path { "/surveys/\(surveyId)/displayed" }
+    func Dismissed(surveyId: String) -> Path { "/surveys/\(surveyId)/dismiss" }
     let Embed: Path = "/surveys/embed"
 }

--- a/Iterate/SDK/UI/Container/Controllers/ContainerViewController.swift
+++ b/Iterate/SDK/UI/Container/Controllers/ContainerViewController.swift
@@ -49,7 +49,7 @@ class ContainerViewController: UIViewController {
         promptViewBottomConstraint.constant > 25 ? hidePrompt() : showPrompt()
     }
     
-    func showPrompt() {
+    func showPrompt(complete: (() -> Void)? = nil) {
         promptView.isHidden = false
         self.promptViewBottomConstraint.constant = promptViewController?.view.frame.height ?? 300
         self.promptViewBottomConstraint.isActive = true
@@ -59,6 +59,12 @@ class ContainerViewController: UIViewController {
         let animator = UIViewPropertyAnimator(duration: 0.5, dampingRatio: 1) {
             self.promptViewBottomConstraint.constant = 0
             self.view.layoutIfNeeded()
+        }
+        
+        if let complete = complete {
+            animator.addCompletion { (_ UIViewAnimatingPosition) in
+                complete()
+            }
         }
         
         animator.startAnimation()
@@ -86,6 +92,6 @@ class ContainerViewController: UIViewController {
 
 extension ContainerViewController: UIAdaptivePresentationControllerDelegate {
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        delegate?.dismissSurvey(userInitiated: true)
+        delegate?.dismissSurvey(survey: survey, userInitiated: true)
     }
 }

--- a/Iterate/SDK/UI/Container/Controllers/ContainerWindowDelegate.swift
+++ b/Iterate/SDK/UI/Container/Controllers/ContainerWindowDelegate.swift
@@ -45,7 +45,9 @@ class ContainerWindowDelegate {
     
             DispatchQueue.main.async {
                 self.showWindow(survey: survey)
-                self.containerViewController?.showPrompt()
+                self.containerViewController?.showPrompt(complete: {
+                    Iterate.shared.api?.displayed(survey: survey, complete: { _, _ in })
+                })
             }
         }
     }
@@ -67,9 +69,9 @@ class ContainerWindowDelegate {
         }
     }
     
-    func dismissPrompt(userInitiated: Bool) {
-        if (userInitiated) {
-            // TODO: Make API call to dismissed
+    func dismissPrompt(survey: Survey?, userInitiated: Bool) {
+        if let survey = survey, userInitiated {
+            Iterate.shared.api?.dismissed(survey: survey, complete: { _, _ in })
         }
         
         containerViewController?.hidePrompt(complete: {
@@ -77,9 +79,9 @@ class ContainerWindowDelegate {
         })
     }
     
-    func dismissSurvey(userInitiated: Bool) {
-        if (userInitiated) {
-            // TODO: Make API call to dismissed
+    func dismissSurvey(survey: Survey?, userInitiated: Bool) {
+        if let survey = survey, userInitiated {
+            Iterate.shared.api?.dismissed(survey: survey, complete: { _, _ in })
         }
         
         self.presentingViewController?.dismiss(animated: true, completion: {

--- a/Iterate/SDK/UI/Survey/Controllers/PromptViewController.swift
+++ b/Iterate/SDK/UI/Survey/Controllers/PromptViewController.swift
@@ -42,6 +42,6 @@ class PromptViewController: UIViewController {
         }
     }
     @IBAction func close(_ sender: Any) {
-        delegate?.dismissPrompt(userInitiated: true)
+        delegate?.dismissPrompt(survey: survey, userInitiated: true)
     }
 }

--- a/Iterate/SDK/UI/Survey/Controllers/SurveyViewController.swift
+++ b/Iterate/SDK/UI/Survey/Controllers/SurveyViewController.swift
@@ -86,7 +86,7 @@ extension SurveyViewController: WKScriptMessageHandler {
             switch messageType {
             case .Close:
                 let userInitiated = data["userInitiated"] as? Bool ?? false
-                delegate?.dismissSurvey(userInitiated: userInitiated)
+                delegate?.dismissSurvey(survey: survey, userInitiated: userInitiated)
             }
         }
     }


### PR DESCRIPTION
We now get the little 3d effect

![2020-06-15 15-40-32 2020-06-15 15_49_37](https://user-images.githubusercontent.com/7181/84699623-d58f3280-af1f-11ea-823f-d8aaccf92acf.gif)

Previously we were presenting the survey on the view controller that's on *our* UIWindow we make, which is why we weren't seeing the underlying app's view get pushed back in that 3D effect...because it wasn't the one presenting the view

This moves to presenting the survey on the app's view controller. We find the right controller by finding the displayed UIWindow, start at it's root view controller, then recursively find what controller that one has displayed...until we get to the end of the chain and that's the "current view controller"

I don't *think* it's too brittle, did a bunch of research and seems right. One issue is if they create more new things like navigation view controller which manage their own view stack in a different way we'll need to update this logic.

I do fallback to using our own view controller, but we could also provide an explicit option that the user could set like Iterate(useGlobalView: true) or something as a fallback


