### PR TITLE
Enable preview mode and send the url schema to the API

### DIFF
--- a/Examples/ModalExample/ModalExample/Info.plist
+++ b/Examples/ModalExample/ModalExample/Info.plist
@@ -16,10 +16,31 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLIconFile</key>
+			<string></string>
+			<key>CFBundleURLName</key>
+			<string>com.iteratehq.ModalExample</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>iterateexample</string>
+			</array>
+		</dict>
+		<dict/>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -60,10 +81,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsLocalNetworking</key>
-		<true/>
-	</dict>
 </dict>
 </plist>

--- a/Examples/ModalExample/ModalExample/SceneDelegate.swift
+++ b/Examples/ModalExample/ModalExample/SceneDelegate.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 Iterate. All rights reserved.
 //
 
+import Iterate
 import UIKit
 
 @available(iOS 13.0, *)
@@ -49,6 +50,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
     }
 
+    
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        for context in URLContexts {
+            if context.url.absoluteString.contains(Iterate.PreviewParameter) {
+                Iterate.shared.preview(url: context.url.absoluteURL)
+            }
+        }
+    }
 
 }
 

--- a/Iterate.xcodeproj/project.pbxproj
+++ b/Iterate.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		27063AB524980D3F00BE6913 /* DismissedEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27063AB424980D3F00BE6913 /* DismissedEndpoint.swift */; };
 		27063AB72498108900BE6913 /* Displayed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27063AB62498108900BE6913 /* Displayed.swift */; };
 		27063AB92498109700BE6913 /* Dismissed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27063AB82498109700BE6913 /* Dismissed.swift */; };
+		274FAFFB249C0B970014C012 /* Scheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274FAFFA249C0B970014C012 /* Scheme.swift */; };
+		274FB000249FAA810014C012 /* Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274FAFFF249FAA810014C012 /* Preview.swift */; };
 		2757AB5B248EDDFE00B909C9 /* PromptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2757AB5A248EDDFE00B909C9 /* PromptViewController.swift */; };
 		2757AB60248FC4FE00B909C9 /* ContainerWindowDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2757AB5F248FC4FE00B909C9 /* ContainerWindowDelegate.swift */; };
 		27821A3C24900C08004AAB22 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27821A3B24900C08004AAB22 /* Color.swift */; };
@@ -95,6 +97,8 @@
 		27063AB424980D3F00BE6913 /* DismissedEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissedEndpoint.swift; sourceTree = "<group>"; };
 		27063AB62498108900BE6913 /* Displayed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Displayed.swift; sourceTree = "<group>"; };
 		27063AB82498109700BE6913 /* Dismissed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dismissed.swift; sourceTree = "<group>"; };
+		274FAFFA249C0B970014C012 /* Scheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scheme.swift; sourceTree = "<group>"; };
+		274FAFFF249FAA810014C012 /* Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preview.swift; sourceTree = "<group>"; };
 		2757AB5A248EDDFE00B909C9 /* PromptViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptViewController.swift; sourceTree = "<group>"; };
 		2757AB5F248FC4FE00B909C9 /* ContainerWindowDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerWindowDelegate.swift; sourceTree = "<group>"; };
 		27821A3B24900C08004AAB22 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
@@ -200,6 +204,7 @@
 			children = (
 				270613D923AE76A100DDF342 /* Configure.swift */,
 				27AEEEA6245DB3F800351EC1 /* SendEvent.swift */,
+				274FAFFF249FAA810014C012 /* Preview.swift */,
 			);
 			path = Methods;
 			sourceTree = "<group>";
@@ -275,6 +280,7 @@
 			isa = PBXGroup;
 			children = (
 				27821A3B24900C08004AAB22 /* Color.swift */,
+				274FAFFA249C0B970014C012 /* Scheme.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -571,6 +577,7 @@
 				27C3B28A23BCF5FC00754F4D /* Context.swift in Sources */,
 				27063AB92498109700BE6913 /* Dismissed.swift in Sources */,
 				27063AB72498108900BE6913 /* Displayed.swift in Sources */,
+				274FAFFB249C0B970014C012 /* Scheme.swift in Sources */,
 				27C3B29723BD354C00754F4D /* Storage.swift in Sources */,
 				27C3B2F123BFDECF00754F4D /* ContainerViewController.swift in Sources */,
 				27C3B28823BAA4BD00754F4D /* Response.swift in Sources */,
@@ -581,6 +588,7 @@
 				27821A3C24900C08004AAB22 /* Color.swift in Sources */,
 				2757AB60248FC4FE00B909C9 /* ContainerWindowDelegate.swift in Sources */,
 				27DDDD5323C657F4005CA07C /* SurveyViewController.swift in Sources */,
+				274FB000249FAA810014C012 /* Preview.swift in Sources */,
 				27C3B2F323C399B200754F4D /* ContainerView.swift in Sources */,
 				27C3B28223BA9BB600754F4D /* Paths.swift in Sources */,
 				27063AB024980D2B00BE6913 /* DisplayedEndpoint.swift in Sources */,

--- a/Iterate/API/Models/Embed.swift
+++ b/Iterate/API/Models/Embed.swift
@@ -11,10 +11,18 @@ import Foundation
 /// Represents the context of the request to the embed endpoint. This includes
 /// things like device type, user traits, and targeting options.
 struct EmbedContext: Codable {
+    var app: AppContext?
     var event: EventContext?
     var targeting: TargetingContext?
     var trigger: TriggerContext?
     var type: EmbedType?
+}
+
+// MARK: App
+
+// Contains data about the application
+struct AppContext: Codable {
+    var urlScheme: String?
 }
 
 // MARK: Event

--- a/Iterate/Helpers/Scheme.swift
+++ b/Iterate/Helpers/Scheme.swift
@@ -1,0 +1,19 @@
+//
+//  Scheme.swift
+//  Iterate
+//
+//  Created by Michael Singleton on 6/18/20.
+//  Copyright © 2020 Pickaxe LLC. (DBA Iterate). All rights reserved.
+//
+
+import Foundation
+
+/// Get the url scheme for the app, this is used to enable preview mode
+func URLScheme() -> String? {
+    guard let urlTypes = Bundle.main.infoDictionary?["CFBundleURLTypes"] as? [AnyObject],
+        let urlTypeDictionary = urlTypes.first as? [String: AnyObject],
+        let urlSchemes = urlTypeDictionary["CFBundleURLSchemes"] as? [AnyObject],
+        let scheme = urlSchemes.first as? String else { return nil }
+
+    return scheme
+}

--- a/Iterate/SDK/Context.swift
+++ b/Iterate/SDK/Context.swift
@@ -15,11 +15,19 @@ extension Iterate {
     /// In the future this may set the current 'view' the user is on, how long they've been
     /// in the app, etc. Anything that may be used for targeting.
     func initCurrentContext() -> EmbedContext {
-        // TODO: Remove. Setting this to be in preview mode so we can force the surveys to show
-        // up until we have a proper preview-mode mechanism.
-        let targeting = TargetingContext(frequency: TargetingContextFrequency.always, surveyId: "5ec54a4857d68f0104c1e97d")
+        // Include the url scheme of the app so we can generate a url to preview the survey
+        var app: AppContext?
+        if let urlScheme = Iterate.shared.urlScheme {
+            app = AppContext(urlScheme: urlScheme)
+        }
         
-        return EmbedContext(targeting: targeting, trigger: nil, type: EmbedType.mobile)
+        // Include the survey id we're previewing
+        var targeting: TargetingContext?
+        if let previewingSurveyId = previewingSurveyId {
+            targeting = TargetingContext(frequency: TargetingContextFrequency.always, surveyId: previewingSurveyId)
+        }
+        
+        return EmbedContext(app: app, targeting: targeting, trigger: nil, type: EmbedType.mobile)
     }
 }
 

--- a/Iterate/SDK/Iterate.swift
+++ b/Iterate/SDK/Iterate.swift
@@ -17,8 +17,14 @@ public class Iterate {
     /// on the Iterate class.
     public static let shared = Iterate()
     
+    /// Query parameter used to set the preview mode
+    public static let PreviewParameter = "iterate_preview"
+    
     /// Storage key used to store the user API key
     static let UserApiStorageKey = "userApiStorageKey"
+    
+    /// URL Scheme of the app, used for previewing surveys
+    lazy var urlScheme = URLScheme()
     
     /// API Client, which will be initialized when the API key is
     var api: APIClient?
@@ -49,6 +55,9 @@ public class Iterate {
             updateApiKey()
         }
     }
+    
+    /// The id of the survey being previewed
+    var previewingSurveyId: String?
     
     /// Storage engine for storing user data like their API key and user attributes
     var storage: StorageEngine

--- a/Iterate/SDK/Methods/Preview.swift
+++ b/Iterate/SDK/Methods/Preview.swift
@@ -1,0 +1,21 @@
+//
+//  Preview.swift
+//  Iterate
+//
+//  Created by Michael Singleton on 6/21/20.
+//  Copyright © 2020 Pickaxe LLC. (DBA Iterate). All rights reserved.
+//
+
+import Foundation
+
+/// Iterate extension that adds the preview method
+extension Iterate {
+    
+    /// Preview processes the custom scheme url that was used to open the app and sets
+    /// the preview mode to the surveyId passed in
+    /// - Parameter url: The URL that opened the application
+    public func preview(url: URL) {
+        let result = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems?.first(where: { $0.name == Iterate.PreviewParameter })?.value
+        previewingSurveyId = result
+    }
+}


### PR DESCRIPTION
After opening a url like: appscheme://anything?iterate_preview=123 it will set the preview mode to the survey id 123.

This also sends the app's url schema to the API so we can use it to generate a preview url