### PR TITLE
Find the right bundle when coming from cocoapods

### DIFF
--- a/Iterate/SDK/Iterate.swift
+++ b/Iterate/SDK/Iterate.swift
@@ -68,6 +68,17 @@ public class Iterate {
     /// Cached copy of the user API key that was loaded from UserDefaults
     private var cachedUserApiKey: String?
     
+    // Get the bundle by identifier or by url (needed when packaging in cocoapods)
+    var bundle: Bundle? {
+        let containerBundle = Bundle(for: ContainerWindowDelegate.self)
+        if let bundleUrl = containerBundle.url(forResource: "Iterate", withExtension: "bundle") {
+            return Bundle(url: bundleUrl)
+        } else {
+            return Bundle(identifier: "com.iteratehq.Iterate")
+        }
+    }
+    
+    
     // MARK: Init
     
     /// Initializer

--- a/Iterate/SDK/UI/Container/Controllers/ContainerWindowDelegate.swift
+++ b/Iterate/SDK/UI/Container/Controllers/ContainerWindowDelegate.swift
@@ -14,13 +14,9 @@ class ContainerWindowDelegate {
         window?.rootViewController as? ContainerViewController
     }
     var surveyViewController: SurveyViewController? {
-        let containerBundle = Bundle(for: ContainerWindowDelegate.self)
-        let bundleUrl = containerBundle.url(forResource: "Iterate", withExtension: "bundle")
-        let bundle = Bundle(url: bundleUrl!)
-        
        return UIStoryboard(
             name: "Surveys",
-            bundle: bundle
+            bundle: Iterate.shared.bundle
         ).instantiateViewController(withIdentifier: "SurveyModalViewController") as? SurveyViewController
     }
     

--- a/Iterate/SDK/UI/Container/Views/ContainerWindow.swift
+++ b/Iterate/SDK/UI/Container/Views/ContainerWindow.swift
@@ -24,12 +24,9 @@ class ContainerWindow: UIWindow {
         }
         
         // Initialize the root view controller
-        let containerBundle = Bundle(for: ContainerWindow.self)
-        let bundleUrl = containerBundle.url(forResource: "Iterate", withExtension: "bundle")
-        let bundle = Bundle(url: bundleUrl!)
         if let containerViewController = UIStoryboard(
             name: "Surveys",
-            bundle: bundle
+            bundle: Iterate.shared.bundle
         ).instantiateViewController(withIdentifier: "ContainerViewController") as? ContainerViewController {
             containerViewController.survey = survey
             containerViewController.delegate = delegate


### PR DESCRIPTION
When loading in dev we can find the bundle directly by it's identifier, when being loaded from cocoapods we need to first find the framework bundle...which we then use to find the resource bundle which includes our storyboards