### PR TITLE
Set light status bar color and refactor dismiss logic

### DIFF
--- a/Iterate/SDK/UI/Container/Controllers/ContainerViewController.swift
+++ b/Iterate/SDK/UI/Container/Controllers/ContainerViewController.swift
@@ -12,6 +12,7 @@ class ContainerViewController: UIViewController {
     var delegate: ContainerWindowDelegate?
     var promptViewController: PromptViewController?
     var survey: Survey?
+    var isSurveyDisplayed: Bool?
     
     @IBOutlet weak var promptView: UIView!
     @IBOutlet weak var promptViewBottomConstraint: NSLayoutConstraint!
@@ -31,6 +32,15 @@ class ContainerViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         promptViewBottomConstraint.constant = 0
         promptViewController?.survey = survey
+    }
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        if let isSurveyDisplayed = isSurveyDisplayed,
+            isSurveyDisplayed {
+            return .lightContent
+        }
+        
+        return .default
     }
     
     @IBAction func handlePan(_ gesture: UIPanGestureRecognizer) {
@@ -87,11 +97,5 @@ class ContainerViewController: UIViewController {
         }
         
         animator.startAnimation()
-    }
-}
-
-extension ContainerViewController: UIAdaptivePresentationControllerDelegate {
-    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        delegate?.dismissSurvey(survey: survey, userInitiated: true)
     }
 }

--- a/Iterate/SDK/UI/Container/Controllers/ContainerWindowDelegate.swift
+++ b/Iterate/SDK/UI/Container/Controllers/ContainerWindowDelegate.swift
@@ -61,6 +61,9 @@ class ContainerWindowDelegate {
                 return
             }
             
+            self.containerViewController?.isSurveyDisplayed = true
+            self.containerViewController?.setNeedsStatusBarAppearanceUpdate()
+            
             // Show the survey
             surveyViewController.survey = survey
             surveyViewController.delegate = self
@@ -79,15 +82,21 @@ class ContainerWindowDelegate {
         })
     }
     
-    func dismissSurvey(survey: Survey?, userInitiated: Bool) {
-        if let survey = survey, userInitiated {
+    /// Dismiss the survey, called when the user clicks the 'X' within the survey
+    func dismissSurvey() {
+        self.presentingViewController?.dismiss(animated: true)
+    }
+    
+    /// Called once a survey has been dismissed, this can happen if a user clicks the 'X' within a survey
+    /// or drags down on the modal view
+    func surveyDismissed(survey: Survey?) {
+        if let survey = survey {
             Iterate.shared.api?.dismissed(survey: survey, complete: { _, _ in })
         }
         
-        self.presentingViewController?.dismiss(animated: true, completion: {
-            self.presentingViewController = nil
-            self.hideWindow()
-        })
+        self.containerViewController?.isSurveyDisplayed = false
+        self.presentingViewController = nil
+        self.hideWindow()
     }
     
     /// Get the currently visible view controller which we will use to modally present the survey and fall back to our container view controller

--- a/Iterate/SDK/UI/Survey/Controllers/SurveyViewController.swift
+++ b/Iterate/SDK/UI/Survey/Controllers/SurveyViewController.swift
@@ -55,6 +55,10 @@ class SurveyViewController: UIViewController {
         }
     }
     
+    override func viewDidDisappear(_ animated: Bool) {
+        delegate?.surveyDismissed(survey: survey)
+    }
+    
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         if keyPath == #keyPath(webView.isLoading) {
             if let change = change,
@@ -78,15 +82,13 @@ extension SurveyViewController: WKScriptMessageHandler {
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         if message.name == MessageHandlerName {
             guard let body = message.body as? [String: AnyObject],
-                let messageType = MessageType(rawValue:body["type"] as? String ?? ""),
-                let data = body["data"] as? [String: AnyObject] else {
+                let messageType = MessageType(rawValue:body["type"] as? String ?? "") else {
                 return
             }
             
             switch messageType {
             case .Close:
-                let userInitiated = data["userInitiated"] as? Bool ?? false
-                delegate?.dismissSurvey(survey: survey, userInitiated: userInitiated)
+                delegate?.dismissSurvey()
             }
         }
     }


### PR DESCRIPTION
Enable light status bar when the survey is displayed, this is done by setting the color of the container view controller

This also refactors the dismiss logic since we weren't removing our window is the survey was dismissed by sliding down on the modal