### PR TITLE
Don't show the prompt when rotating

### DIFF
--- a/Iterate/SDK/UI/Container/Controllers/ContainerViewController.swift
+++ b/Iterate/SDK/UI/Container/Controllers/ContainerViewController.swift
@@ -76,8 +76,11 @@ class ContainerViewController: UIViewController {
             self.promptViewBottomConstraint.constant = 0
             self.promptViewBottomConstraint.isActive = false
             self.promptViewTopConstraint.isActive = true
-            
             self.view.layoutIfNeeded()
+        }
+        
+        animator.addCompletion { (_ UIViewAnimatingPosition) in
+            self.promptView.isHidden = true
         }
         
         if let complete = complete {


### PR DESCRIPTION
When it rotates it re-runs autolayout which caused this to pop back up. There are a few ways to fix this but the easiest was just setting the view to Hidden when it's been hidden (previously it had just animated out of view but technically was still visible)