### PR TITLE
Add support for event properties

### DIFF
--- a/Examples/ModalExample/ModalExample/ViewController.swift
+++ b/Examples/ModalExample/ModalExample/ViewController.swift
@@ -17,6 +17,11 @@ class ViewController: UIViewController {
     }
 
     @IBAction func showSurvey(_ sender: Any) {
+        Iterate.shared.identify(responseProperties: [
+            "exampleString": ResponsePropertyValue("string value"),
+            "exampleNumber": ResponsePropertyValue(123),
+            "exampleBoolean": ResponsePropertyValue(true),
+        ])
         Iterate.shared.sendEvent(name: Event.ShowSurveyButtonTapped.rawValue)
     }
 }

--- a/Iterate/API/Models/Embed.swift
+++ b/Iterate/API/Models/Embed.swift
@@ -72,6 +72,7 @@ enum EmbedType: String, Codable {
 // MARK: Properties
 
 public typealias UserProperties = [String: UserPropertyValue]
+public typealias ResponseProperties = [String: ResponsePropertyValue]
 
 /// User property values can be a string, int, or bool
 public struct UserPropertyValue: Codable {
@@ -96,5 +97,27 @@ public struct UserPropertyValue: Codable {
 
     public func encode(to encoder: Encoder) throws {
         try _encode(encoder)
+    }
+}
+
+public struct ResponsePropertyValue {
+    let value: Any
+    
+    public init(_ value: Any) {
+        self.value = value
+    }
+    
+    /// Returns a string representing the type of the value, this is used
+    /// when passing the value into the survey webview as a
+    /// query parameter
+    public func typeString() -> String {
+        switch value {
+        case _ as Bool:
+            return "_boolean"
+        case _ as Int:
+            return "_number"
+        default:
+            return ""
+        }
     }
 }

--- a/Iterate/SDK/Iterate.swift
+++ b/Iterate/SDK/Iterate.swift
@@ -107,6 +107,8 @@ public class Iterate {
     /// Cached copy of the user properties that was loaded from UserDefaults
     private var cachedUserProperties: UserProperties?
     
+    var responseProperties: ResponseProperties?
+    
     // MARK: Init
     
     /// Initializer

--- a/Iterate/SDK/Methods/Identify.swift
+++ b/Iterate/SDK/Methods/Identify.swift
@@ -14,4 +14,8 @@ extension Iterate {
         self.userProperties = userProperties
     }
     
+    public func identify(responseProperties: ResponseProperties?) {
+        self.responseProperties = responseProperties
+    }
+    
 }

--- a/Iterate/SDK/UI/Survey/Controllers/SurveyViewController.swift
+++ b/Iterate/SDK/UI/Survey/Controllers/SurveyViewController.swift
@@ -51,14 +51,24 @@ class SurveyViewController: UIViewController {
         if let survey = survey {
             let host = Iterate.shared.apiHost ?? DefaultAPIHost
             
+            var params: [String] = []
+            
             // Include the user's auth token as a query param. The web view
             // will use this token to authorize API calls
-            var authTokenParam = ""
             if let authToken = Iterate.shared.userApiKey {
-                authTokenParam = "auth_token=\(authToken)"
+                params.append("auth_token=\(authToken)")
             }
             
-            let myRequest = URLRequest(url: URL(string:"\(host)/\(survey.companyId)/\(survey.id)/mobile?\(authTokenParam)")!)
+            // Include response properties. These are in the format of response_[type]_[name]=[value]
+            // e.g. response_number_userId=123
+            if let responseProperties = Iterate.shared.responseProperties {
+                params.append(contentsOf: responseProperties.map {
+                    let value = "\($0.value.value)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+                    return "response\($0.value.typeString())_\($0.key)=\(value)" })
+            }
+            
+            let url = "\(host)/\(survey.companyId)/\(survey.id)/mobile?\(params.joined(separator: "&"))"
+            let myRequest = URLRequest(url: URL(string: url)!)
             webView.load(myRequest)
         }
     }


### PR DESCRIPTION
Adds an additional option for `Iterate.shared.identify(responseProperties: ...)`

We then pass the response properties into the webview as query parmeters, which already support response properties