### PR TITLE
Prevent re-presenting prompt when swiping up

### DIFF
--- a/Examples/ModalExample/ModalExample/SettingsViewController.swift
+++ b/Examples/ModalExample/ModalExample/SettingsViewController.swift
@@ -41,7 +41,8 @@ class SettingsViewController: UIViewController, UITextFieldDelegate {
     @IBAction func onApiKeyEditingChanged(_ sender: UITextField) {
         UserDefaults.standard.set(apiKeyTextField.text, forKey: ApiKeyKey)
         
-        Iterate.shared.configure(apiKey: apiKeyTextField.text ?? "")
+        let apiHost = Environment(rawValue: UserDefaults.standard.integer(forKey: EnvironmentKey)) == Environment.Development ? EnvironmentUrl.Development : EnvironmentUrl.Production
+        Iterate.shared.configure(apiKey: apiKeyTextField.text ?? "", apiHost: apiHost.rawValue)
     }
     
     @IBAction func onEnvironmentChanged(_ sender: UISegmentedControl) {

--- a/Iterate/SDK/Iterate.swift
+++ b/Iterate/SDK/Iterate.swift
@@ -80,11 +80,12 @@ public final class Iterate {
         }
         
         set(newUserApiKey) {
-            guard let newUserApiKey = newUserApiKey else {
-                return
+            if let newUserApiKey = newUserApiKey {
+                storage.set(value: newUserApiKey, for: StorageKeys.UserApiKey)
+            } else {
+                storage.delete(for: StorageKeys.UserApiKey)
             }
             
-            storage.set(value: newUserApiKey, for: StorageKeys.UserApiKey)
             updateApiKey()
         }
     }

--- a/Iterate/SDK/UI/Container/Controllers/ContainerViewController.swift
+++ b/Iterate/SDK/UI/Container/Controllers/ContainerViewController.swift
@@ -44,7 +44,15 @@ final class ContainerViewController: UIViewController {
             return
         }
         
-        promptViewBottomConstraint.constant > 25 ? hidePrompt() : showPrompt()
+        if promptViewBottomConstraint.constant > 25 {
+            hidePrompt()
+        } else {
+            let animator = UIViewPropertyAnimator(duration: 0.2, dampingRatio: 1) {
+                self.promptViewBottomConstraint.constant = 0
+                self.view.layoutIfNeeded()
+            }
+            animator.startAnimation()
+        }
     }
     
     func showPrompt(complete: (() -> Void)? = nil) {

--- a/Iterate/Storage/KeychainStorageEngine.swift
+++ b/Iterate/Storage/KeychainStorageEngine.swift
@@ -58,6 +58,14 @@ final class KeychainStorageEngine: StorageEngine {
         }
     }
     
+    /// Delete the value associated with the key
+    func delete(for key: StorageKeys) -> Void {
+        let status = SecItemDelete(query(for: key) as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            assertionFailure("Unable to delete item to keychain")
+        }
+    }
+    
     private func query(for key: StorageKeys) -> [String: Any] {
         return  [
                    kSecClass as String: kSecClassGenericPassword,

--- a/Iterate/Storage/Storage.swift
+++ b/Iterate/Storage/Storage.swift
@@ -10,6 +10,7 @@ import Foundation
 
 /// Protocol to represent a simple get/set storage engine
 protocol StorageEngine {
+    func delete(for key: StorageKeys) -> Void
     func value(for key: StorageKeys) -> String?
     func set(value: String, for key: StorageKeys) -> Void
 }

--- a/IterateTests/Mocks/MockStorageEngine.swift
+++ b/IterateTests/Mocks/MockStorageEngine.swift
@@ -19,6 +19,10 @@ class MockStorageEngine: StorageEngine {
         storage[key] ?? nil
     }
     
+    func delete(for key: StorageKeys) -> Void {
+        storage[key] = nil
+    }
+    
     /// Set a value using the key
     /// - Parameters:
     ///   - key: Key to set


### PR DESCRIPTION
Previously if you swiped up on the prompt it would snap down below the bottom of the screen and re-resent. This adds an animation to put the prompt back where it was previously