### PR TITLE
Clear user api key when company api key changes

### DIFF
--- a/Examples/ModalExample/ModalExample/SettingsViewController.swift
+++ b/Examples/ModalExample/ModalExample/SettingsViewController.swift
@@ -41,7 +41,8 @@ class SettingsViewController: UIViewController, UITextFieldDelegate {
     @IBAction func onApiKeyEditingChanged(_ sender: UITextField) {
         UserDefaults.standard.set(apiKeyTextField.text, forKey: ApiKeyKey)
         
-        Iterate.shared.configure(apiKey: apiKeyTextField.text ?? "")
+        let apiHost = Environment(rawValue: UserDefaults.standard.integer(forKey: EnvironmentKey)) == Environment.Development ? EnvironmentUrl.Development : EnvironmentUrl.Production
+        Iterate.shared.configure(apiKey: apiKeyTextField.text ?? "", apiHost: apiHost.rawValue)
     }
     
     @IBAction func onEnvironmentChanged(_ sender: UISegmentedControl) {

--- a/Iterate/SDK/Iterate.swift
+++ b/Iterate/SDK/Iterate.swift
@@ -80,11 +80,12 @@ public final class Iterate {
         }
         
         set(newUserApiKey) {
-            guard let newUserApiKey = newUserApiKey else {
-                return
+            if let newUserApiKey = newUserApiKey {
+                storage.set(value: newUserApiKey, for: StorageKeys.UserApiKey)
+            } else {
+                storage.delete(for: StorageKeys.UserApiKey)
             }
             
-            storage.set(value: newUserApiKey, for: StorageKeys.UserApiKey)
             updateApiKey()
         }
     }

--- a/Iterate/Storage/KeychainStorageEngine.swift
+++ b/Iterate/Storage/KeychainStorageEngine.swift
@@ -58,6 +58,14 @@ final class KeychainStorageEngine: StorageEngine {
         }
     }
     
+    /// Delete the value associated with the key
+    func delete(for key: StorageKeys) -> Void {
+        let status = SecItemDelete(query(for: key) as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            assertionFailure("Unable to delete item to keychain")
+        }
+    }
+    
     private func query(for key: StorageKeys) -> [String: Any] {
         return  [
                    kSecClass as String: kSecClassGenericPassword,

--- a/Iterate/Storage/Storage.swift
+++ b/Iterate/Storage/Storage.swift
@@ -10,6 +10,7 @@ import Foundation
 
 /// Protocol to represent a simple get/set storage engine
 protocol StorageEngine {
+    func delete(for key: StorageKeys) -> Void
     func value(for key: StorageKeys) -> String?
     func set(value: String, for key: StorageKeys) -> Void
 }

--- a/IterateTests/Mocks/MockStorageEngine.swift
+++ b/IterateTests/Mocks/MockStorageEngine.swift
@@ -19,6 +19,10 @@ class MockStorageEngine: StorageEngine {
         storage[key] ?? nil
     }
     
+    func delete(for key: StorageKeys) -> Void {
+        storage[key] = nil
+    }
+    
     /// Set a value using the key
     /// - Parameters:
     ///   - key: Key to set


### PR DESCRIPTION
The keychain persists data beyond uninstalling the app like NSUserDefaults does so we need a way to clean the user api key to make it easier to test with the example app