### PR TITLE
Don't show a survey if we're already showing one

### DIFF
--- a/IterateSDK/SDK/UI/Container/Controllers/ContainerViewController.swift
+++ b/IterateSDK/SDK/UI/Container/Controllers/ContainerViewController.swift
@@ -45,7 +45,7 @@ final class ContainerViewController: UIViewController {
         }
         
         if promptViewBottomConstraint.constant > 25 {
-            hidePrompt()
+            delegate?.dismissPrompt(survey: survey, userInitiated: true)
         } else {
             let animator = UIViewPropertyAnimator(duration: 0.2, dampingRatio: 1) {
                 self.promptViewBottomConstraint.constant = 0

--- a/IterateSDK/SDK/UI/Container/Controllers/ContainerWindowDelegate.swift
+++ b/IterateSDK/SDK/UI/Container/Controllers/ContainerWindowDelegate.swift
@@ -13,6 +13,7 @@ final class ContainerWindowDelegate {
     private var containerViewController: ContainerViewController? {
         window?.rootViewController as? ContainerViewController
     }
+    var isSurveyOrPromptDisplayed: Bool?
     
     /// Show the window
     func showWindow(survey: Survey) {
@@ -27,10 +28,18 @@ final class ContainerWindowDelegate {
     func hideWindow() {
         window?.isHidden = true
         window = nil
+        isSurveyOrPromptDisplayed = false
     }
     
     /// Show either the prompt (if there is one) or the survey
     func show(_ survey: Survey) {
+        // Don't show another survey if we're already showing one
+        if let isSurveyOrPromptDisplayed = isSurveyOrPromptDisplayed, isSurveyOrPromptDisplayed {
+            return
+        }
+        
+        isSurveyOrPromptDisplayed = true
+        
         if survey.prompt != nil {
             showPrompt(survey)
         } else {


### PR DESCRIPTION
Prevents a prompt from re-presenting if it's already shown (matches the logic we have on web currently)