### PR TITLE
Move webview request from viewWillAppear to viewDidLoad

### DIFF
--- a/IterateSDK/SDK/UI/Survey/Controllers/SurveyViewController.swift
+++ b/IterateSDK/SDK/UI/Survey/Controllers/SurveyViewController.swift
@@ -66,10 +66,7 @@ final class SurveyViewController: UIViewController {
         view.bringSubviewToFront(loadingView)
         view.bringSubviewToFront(errorLoadingLabel)
         view.bringSubviewToFront(closeButton)
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+        
         
         if let survey = survey {
             let host = Iterate.shared.apiHost ?? Iterate.DefaultAPIHost
@@ -95,6 +92,7 @@ final class SurveyViewController: UIViewController {
             webView.load(myRequest)
         }
     }
+    
     @IBAction func closeSurvey(_ sender: Any) {
         delegate?.dismissSurvey()
     }


### PR DESCRIPTION
`viewWillAppear` was being called when the modal view was dragged, causing the webview to be reloaded