### PR TITLE
Open non-Iterate links in a new browser window

### DIFF
--- a/IterateSDK/SDK/UI/Survey/Controllers/SurveyViewController.swift
+++ b/IterateSDK/SDK/UI/Survey/Controllers/SurveyViewController.swift
@@ -128,4 +128,30 @@ extension SurveyViewController: WKNavigationDelegate {
             errorLoadingLabel.isHidden = false
             closeButton.isHidden = false
     }
+    
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.cancel)
+            return
+        }
+        
+        if let urlScheme = url.scheme, let urlHost = url.host {
+            var baseUrl = "\(urlScheme)://\(urlHost)"
+            if let urlPort = url.port {
+                baseUrl += ":\(urlPort)"
+            }
+            
+            if baseUrl != Iterate.shared.apiHost {
+                UIApplication.shared.open(url)
+                
+                decisionHandler(.cancel)
+                return
+            }
+        }
+        
+        
+            
+
+        decisionHandler(.allow)
+    }
 }


### PR DESCRIPTION
Surveys can contain external links, either via markdown in the question prompt or other copy, or via the "Redirect to URL" action of a branch. These links should always be opened in a new browser window, to avoid the confusing UX of another site being displayed in the in-app webview.