### PR TITLE
Add workarounds for "Iterate may not show correctly in apps that manage multiple windows"

### DIFF
--- a/IterateSDK/SDK/Iterate.swift
+++ b/IterateSDK/SDK/Iterate.swift
@@ -230,7 +230,7 @@ public final class Iterate {
         responseProperties = nil
     }
     
-    public func setFallback(windowTag: Int) {
+    public func setFallback(windowTag: Int?) {
         fallbackWindowTag = windowTag
     }
     

--- a/IterateSDK/SDK/Iterate.swift
+++ b/IterateSDK/SDK/Iterate.swift
@@ -44,6 +44,9 @@ public final class Iterate {
     /// The name of a custom font to be used for buttons in the prompt and survey UI
     var buttonFontName: String?
     
+    /// If set, Iterate's container window will be given a tag that can be compared to later.
+    var iterateWindowTag: Int?
+    
     /// The fallback window tag for when Iterate determines that it became the key window and tries to avoid itself.
     /// This may help resolve issues if your app handles multiple windows and tries to open Iterate from any other than the first window.
     var fallbackWindowTag: Int?
@@ -219,6 +222,10 @@ public final class Iterate {
         self.responseProperties = responseProperties
     }
     
+    public func identify(windowTag: Int?) {
+        self.iterateWindowTag = windowTag
+    }
+    
     public func reset() {
         // Clear everything from storage
         self.storage.clear()
@@ -232,6 +239,10 @@ public final class Iterate {
     
     public func setFallback(windowTag: Int?) {
         fallbackWindowTag = windowTag
+    }
+    
+    public func hideWindow() {
+        container.hideWindow()
     }
     
     // MARK: Private methods

--- a/IterateSDK/SDK/Iterate.swift
+++ b/IterateSDK/SDK/Iterate.swift
@@ -44,6 +44,10 @@ public final class Iterate {
     /// The name of a custom font to be used for buttons in the prompt and survey UI
     var buttonFontName: String?
     
+    /// The fallback window tag for when Iterate determines that it became the key window and tries to avoid itself.
+    /// This may help resolve issues if your app handles multiple windows and tries to open Iterate from any other than the first window.
+    var fallbackWindowTag: Int?
+    
     /// Storage engine for storing user data like their API key and user attributes
     private var storage: StorageEngine
     
@@ -224,6 +228,10 @@ public final class Iterate {
         
         // Clear response properties
         responseProperties = nil
+    }
+    
+    public func setFallback(windowTag: Int) {
+        fallbackWindowTag = windowTag
     }
     
     // MARK: Private methods

--- a/IterateSDK/SDK/UI/Container/Controllers/ContainerWindowDelegate.swift
+++ b/IterateSDK/SDK/UI/Container/Controllers/ContainerWindowDelegate.swift
@@ -19,6 +19,10 @@ final class ContainerWindowDelegate {
     func showWindow(survey: Survey) {
         if window == nil {
             window = PassthroughWindow(survey: survey, delegate: self)
+            
+            if let windowTag = Iterate.shared.iterateWindowTag {
+                window?.tag = windowTag
+            }
         }
         
         window?.isHidden = false

--- a/IterateSDK/SDK/UI/Container/Controllers/ContainerWindowDelegate.swift
+++ b/IterateSDK/SDK/UI/Container/Controllers/ContainerWindowDelegate.swift
@@ -101,7 +101,14 @@ final class ContainerWindowDelegate {
     func getPresentingViewController() -> UIViewController? {
         // Find the first key window that is not our own passthrough window
         var window = UIApplication.shared.windows.first { $0.isKeyWindow && $0 != self.window }
+        
+        // If we didn't find one, but we do have a fallbackWindowTag, try retrieve a window with that tag instead.
+        if window == nil, let fallbackWindowTag = Iterate.shared.fallbackWindowTag {
+            window = UIApplication.shared.windows.first { $0.tag == fallbackWindowTag }
+        }
+        
         // If we didn't find one, get the first non-key window since our window may be key (happens in iOS 14.2)
+        // If your app uses multiple windows and enters this if, consider setting a fallbackWindowTag.
         if window == nil {
            window = UIApplication.shared.windows.first { $0 != self.window }
         }


### PR DESCRIPTION
This pull request provides alternatives to work around issue https://github.com/iteratehq/iterate-ios/issues/78

In short, I added:
- Support for setting a fallback window tag for Iterate to try and look for before defaulting to using the first window.
- Support for setting a tag on Iterate's window, useful for forcing it to be displayed in a certain orientation (landscape) based on circumstances.
- Support for hiding the container window manually, so Iterate can be reset if it ever reaches a broken state during a session. This mostly eased troubles during testing fixes, but is not actually necessary now our problem has been resolved.