### PR TITLE
Include all parameters in the file url

### DIFF
--- a/IterateSDK/SDK/UI/Survey/Controllers/SurveyViewController.swift
+++ b/IterateSDK/SDK/UI/Survey/Controllers/SurveyViewController.swift
@@ -105,10 +105,7 @@ final class SurveyViewController: UIViewController {
                 do {
                     if let url = URL(string: urlString) {
                         let html = try String(contentsOf: url)
-                        var baseUrlString = Bundle.main.bundleURL.absoluteString
-                        if let authToken = Iterate.shared.userApiKey {
-                            baseUrlString = "\(baseUrlString)?auth_token=\(authToken)"
-                        }
+                        let baseUrlString = "\(Bundle.main.bundleURL.absoluteString)?\(params.joined(separator: "&"))"
                         DispatchQueue.main.async {
                             self.webView.loadHTMLString(html, baseURL: URL(string: baseUrlString))
                         }


### PR DESCRIPTION
Previously we omitted any other parameter from the URL including user traits and response traits. This meant that response traits were not passed at all and user traits were not available to be used in mustache templates (they were sent to the API, but as part of the embed request)