### PR TITLE
Easier preview URL detection

### DIFF
--- a/Examples/ModalExample/ModalExample/SceneDelegate.swift
+++ b/Examples/ModalExample/ModalExample/SceneDelegate.swift
@@ -53,7 +53,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         for context in URLContexts {
-            if (context.url.isIteratePreviewURL) {
+            if context.url.isIteratePreviewURL {
                 Iterate.shared.preview(url: context.url.absoluteURL)
             }
         }

--- a/Examples/ModalExample/ModalExample/SceneDelegate.swift
+++ b/Examples/ModalExample/ModalExample/SceneDelegate.swift
@@ -53,7 +53,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         for context in URLContexts {
-            if (URLComponents(url: context.url, resolvingAgainstBaseURL: false)?.queryItems?.contains { $0.name == Iterate.PreviewParameter } ?? false) {
+            if (context.url.isIteratePreviewURL) {
                 Iterate.shared.preview(url: context.url.absoluteURL)
             }
         }

--- a/Iterate.xcodeproj/project.pbxproj
+++ b/Iterate.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		27C3B2F323C399B200754F4D /* PassthroughView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C3B2F223C399B200754F4D /* PassthroughView.swift */; };
 		27D6D68C24881A45005DD502 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27D6D68B24881A45005DD502 /* WebKit.framework */; platformFilter = ios; };
 		27DDDD5323C657F4005CA07C /* SurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27DDDD5223C657F4005CA07C /* SurveyViewController.swift */; };
+		2C0F0B0829BF8C3E000BD234 /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0F0B0429BF8C3E000BD234 /* URL.swift */; };
 		2C8162602880621600B2AE48 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C81625F2880621600B2AE48 /* Font.swift */; };
 /* End PBXBuildFile section */
 
@@ -114,6 +115,7 @@
 		27C3B2F223C399B200754F4D /* PassthroughView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassthroughView.swift; sourceTree = "<group>"; };
 		27D6D68B24881A45005DD502 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/WebKit.framework; sourceTree = DEVELOPER_DIR; };
 		27DDDD5223C657F4005CA07C /* SurveyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewController.swift; sourceTree = "<group>"; };
+		2C0F0B0429BF8C3E000BD234 /* URL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
 		2C81625F2880621600B2AE48 /* Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -261,6 +263,7 @@
 		27821A3724900BE9004AAB22 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				2C0F0B0429BF8C3E000BD234 /* URL.swift */,
 				27821A3B24900C08004AAB22 /* Color.swift */,
 				274FAFFA249C0B970014C012 /* Scheme.swift */,
 				2C81625F2880621600B2AE48 /* Font.swift */,
@@ -574,6 +577,7 @@
 				27063AB024980D2B00BE6913 /* DisplayedEndpoint.swift in Sources */,
 				270613D823AD8D6200DDF342 /* Iterate.swift in Sources */,
 				27C3B2EF23BFD44400754F4D /* PassthroughWindow.swift in Sources */,
+				2C0F0B0829BF8C3E000BD234 /* URL.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/IterateSDK/Helpers/URL.swift
+++ b/IterateSDK/Helpers/URL.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension URL {
+public extension URL {
     
     /// Returns true 
     var isIteratePreviewURL: Bool {

--- a/IterateSDK/Helpers/URL.swift
+++ b/IterateSDK/Helpers/URL.swift
@@ -1,0 +1,17 @@
+//
+//  URL.swift
+//  
+//
+//  Created by Matthew Bischoff on 3/13/23.
+//  Copyright © 2020 Pickaxe LLC. (DBA Iterate). All rights reserved.
+//
+
+import Foundation
+
+extension URL {
+    
+    /// Returns true 
+    var isIteratePreviewURL: Bool {
+        return URLComponents(url: self, resolvingAgainstBaseURL: false)?.queryItems?.contains { $0.name == Iterate.PreviewParameter } ?? false
+    }
+}

--- a/IterateSDK/Helpers/URL.swift
+++ b/IterateSDK/Helpers/URL.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public extension URL {
     
-    /// Returns true 
+    /// Returns `true` if the receiver contains the Iterate preview parameter.
     var isIteratePreviewURL: Bool {
         return URLComponents(url: self, resolvingAgainstBaseURL: false)?.queryItems?.contains { $0.name == Iterate.PreviewParameter } ?? false
     }

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
   func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
       for context in URLContexts {
-          if (URLComponents(url: context.url, resolvingAgainstBaseURL: false)?.queryItems?.contains { $0.name == Iterate.PreviewParameter } ?? false) {
+          if context.url.isIteratePreviewURL {
               Iterate.shared.preview(url: context.url.absoluteURL)
           }
       }


### PR DESCRIPTION
## What it Does

* Makes the code for detecting and handling Iterate Preview URLs in the Client app’s AppDelegate cleaner and more straightforward via an extension on `URL`
* Replaces the relevant code in the docs and example project.

❤️