### PR TITLE
Fix decoding of survey JSON responses without dark mode colors

### DIFF
--- a/IterateSDK/API/Models/Survey.swift
+++ b/IterateSDK/API/Models/Survey.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public struct Survey: Codable {
     let colorHex: String
-    let colorDarkHex: String
+    let colorDarkHex: String?
     let companyId: String
     let id: String
     let prompt: Prompt?

--- a/IterateSDK/SDK/UI/Survey/Controllers/PromptViewController.swift
+++ b/IterateSDK/SDK/UI/Survey/Controllers/PromptViewController.swift
@@ -43,7 +43,7 @@ final class PromptViewController: UIViewController {
         if self.traitCollection.userInterfaceStyle == .dark {
             view.backgroundColor = UIColor(hex: Colors.LightBlack.rawValue)
             self.closeButton.backgroundColor = UIColor(hex: Colors.LightBlack.rawValue)
-            if let darkColor = survey?.colorDarkHex {
+            if let darkColor = survey?.colorDarkHex ?? survey?.colorHex {
                 promptButton.backgroundColor = UIColor(hex: darkColor)
             }
         } else {


### PR DESCRIPTION
Hey Iterate team,

We've noticed that when a survey's primary color is set to the same color for both light and dark mode, the `colorDark` field is elided in the JSON response returned by the `/v1/surveys/embed` endpoint.

However, `colorDarkHex` is non-optional in the [`Survey`](https://github.com/iteratehq/iterate-ios/blob/28a1b4c78031c94abc83437b70449d2e82e2fcaf/IterateSDK/API/Models/Survey.swift) model. As such, when a survey with the same color for both light and dark mode is loaded, decoding fails and it is never presented to the user.

This patch makes the `colorDarkHex` field on `Survey` optional, and falls back to `colorHex` in dark mode if it is not present.

Thanks,
Lachy