### PR TITLE
Set any response properties returned from the server

### DIFF
--- a/IterateSDK/API/Endpoints/EmbedEndpoint.swift
+++ b/IterateSDK/API/Endpoints/EmbedEndpoint.swift
@@ -11,6 +11,7 @@ import Foundation
 /// Embed response
 struct EmbedResponse: Codable {
     let auth: EmbedAuth?
+    let eventTraits: UserProperties?
     let survey: Survey?
     let tracking: TrackingContext?
 }

--- a/IterateSDK/SDK/Iterate.swift
+++ b/IterateSDK/SDK/Iterate.swift
@@ -248,6 +248,15 @@ public final class Iterate {
                 self.trackingLastUpdated = lastUpdated
             }
             
+            // Use eventTraits as responseProperties if they were returned
+            if let eventTraits = response?.eventTraits {
+                var properties = ResponseProperties()
+                for (key, value) in eventTraits {
+                    properties[key] = ResponsePropertyValue(value.value)
+                }
+                self.responseProperties = properties
+            }
+            
             complete(response, error)
         })
     }

--- a/IterateSDK/SDK/Iterate.swift
+++ b/IterateSDK/SDK/Iterate.swift
@@ -250,7 +250,7 @@ public final class Iterate {
             
             // Use eventTraits as responseProperties if they were returned
             if let eventTraits = response?.eventTraits {
-                var properties = ResponseProperties()
+                var properties = self.responseProperties ?? ResponseProperties()
                 for (key, value) in eventTraits {
                     properties[key] = ResponsePropertyValue(value.value)
                 }


### PR DESCRIPTION
Currently the only use case is setting the event which triggered a survey, but it works as a general purpose feature