### PR TITLE
Fix survey prompt behind app windows

### DIFF
--- a/Iterate.xcodeproj/project.pbxproj
+++ b/Iterate.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		2757AB60248FC4FE00B909C9 /* ContainerWindowDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2757AB5F248FC4FE00B909C9 /* ContainerWindowDelegate.swift */; };
 		27821A3C24900C08004AAB22 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27821A3B24900C08004AAB22 /* Color.swift */; };
 		27821A3E2492B89C004AAB22 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 27821A3D2492B89C004AAB22 /* Assets.xcassets */; };
+		2C1F90012DF7533500C8F0F1 /* PromptWindowLevelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1F90002DF7533500C8F0F1 /* PromptWindowLevelTests.swift */; };
 		27C3B27C23BA832300754F4D /* ClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C3B27B23BA832300754F4D /* ClientTests.swift */; };
 		27C3B28223BA9BB600754F4D /* Paths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C3B28123BA9BB600754F4D /* Paths.swift */; };
 		27C3B28623BAA3A900754F4D /* EmbedEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C3B28523BAA3A900754F4D /* EmbedEndpoint.swift */; };
@@ -103,6 +104,7 @@
 		2757AB5F248FC4FE00B909C9 /* ContainerWindowDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerWindowDelegate.swift; sourceTree = "<group>"; };
 		27821A3B24900C08004AAB22 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		27821A3D2492B89C004AAB22 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		2C1F90002DF7533500C8F0F1 /* PromptWindowLevelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptWindowLevelTests.swift; sourceTree = "<group>"; };
 		27C3B27B23BA832300754F4D /* ClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientTests.swift; sourceTree = "<group>"; };
 		27C3B28123BA9BB600754F4D /* Paths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paths.swift; sourceTree = "<group>"; };
 		27C3B28523BAA3A900754F4D /* EmbedEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedEndpoint.swift; sourceTree = "<group>"; };
@@ -344,6 +346,7 @@
 			children = (
 				27C3B29223BD29A300754F4D /* Methods */,
 				270613CB23AD862C00DDF342 /* IterateTests.swift */,
+				2C1F90002DF7533500C8F0F1 /* PromptWindowLevelTests.swift */,
 			);
 			path = SDK;
 			sourceTree = "<group>";
@@ -604,6 +607,7 @@
 				270613DC23AE773500DDF342 /* ConfigureTests.swift in Sources */,
 				27C3B29C23BD3FA400754F4D /* MockStorageEngine.swift in Sources */,
 				270613CC23AD862C00DDF342 /* IterateTests.swift in Sources */,
+				2C1F90012DF7533500C8F0F1 /* PromptWindowLevelTests.swift in Sources */,
 				27C3B29423BD2A7F00754F4D /* ShowTests.swift in Sources */,
 				27C3B27C23BA832300754F4D /* ClientTests.swift in Sources */,
 				27C3B29123BD1E7D00754F4D /* EmbedEndpointTests.swift in Sources */,

--- a/IterateSDK/SDK/UI/Container/Views/PassthroughWindow.swift
+++ b/IterateSDK/SDK/UI/Container/Views/PassthroughWindow.swift
@@ -13,12 +13,14 @@ import UIKit
 /// current application window ensuring it an be displayed anywhere at anytime.
 final class PassthroughWindow: UIWindow {
     init(survey: Survey, delegate: ContainerWindowDelegate) {
+        let presentingWindow = PassthroughWindow.frontmostApplicationWindow()
+
         if #available(iOS 13.0, *) {
-            // Attach the window to the first foreground active UIWindowScene
-            if let scene = UIApplication.shared.connectedScenes
-                .filter({ $0.activationState == .foregroundActive })
-                .compactMap({$0 as? UIWindowScene})
-                .first {
+            let fallbackScene = UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .first { $0.activationState == .foregroundActive }
+
+            if let scene = presentingWindow?.windowScene ?? fallbackScene {
                 super.init(windowScene: scene)
             } else {
                 super.init(frame: UIScreen.main.bounds)
@@ -26,6 +28,8 @@ final class PassthroughWindow: UIWindow {
         } else {
             super.init(frame: UIScreen.main.bounds)
         }
+
+        windowLevel = PassthroughWindow.promptWindowLevel(above: presentingWindow?.windowLevel)
         
         // Initialize the root view controller
         if let containerViewController = UIStoryboard(
@@ -43,6 +47,14 @@ final class PassthroughWindow: UIWindow {
     required init?(coder: NSCoder) {
         fatalError("init from coder not supported")
     }
+
+    static func promptWindowLevel(above windowLevel: UIWindow.Level?) -> UIWindow.Level {
+        let normalWindowLevel = UIWindow.Level.normal.rawValue
+        let desiredWindowLevel = (windowLevel?.rawValue ?? normalWindowLevel) + 1
+        let maximumPromptWindowLevel = UIWindow.Level.alert.rawValue - 1
+
+        return UIWindow.Level(rawValue: min(desiredWindowLevel, maximumPromptWindowLevel))
+    }
     
     /// Override the hit test to ignore hits on the window itself, this way it will pass through events to underlying views
     /// - Parameters:
@@ -58,5 +70,24 @@ final class PassthroughWindow: UIWindow {
         }
         
         return nil
+    }
+
+    private static func frontmostApplicationWindow() -> UIWindow? {
+        let maximumPromptWindowLevel = UIWindow.Level.alert.rawValue - 1
+
+        return UIApplication.shared.windows
+            .filter {
+                !$0.isHidden &&
+                    $0.rootViewController != nil &&
+                    !($0 is PassthroughWindow) &&
+                    $0.windowLevel.rawValue < maximumPromptWindowLevel
+            }
+            .max { lhs, rhs in
+                if lhs.windowLevel == rhs.windowLevel {
+                    return !lhs.isKeyWindow && rhs.isKeyWindow
+                }
+
+                return lhs.windowLevel.rawValue < rhs.windowLevel.rawValue
+            }
     }
 }

--- a/IterateSDKTests/Unit/SDK/PromptWindowLevelTests.swift
+++ b/IterateSDKTests/Unit/SDK/PromptWindowLevelTests.swift
@@ -1,0 +1,23 @@
+//
+//  PromptWindowLevelTests.swift
+//  IterateTests
+//
+
+import XCTest
+@testable import Iterate
+
+final class PromptWindowLevelTests: XCTestCase {
+    func testPromptWindowAppearsAboveElevatedNormalHostWindow() {
+        let hostWindowLevel = UIWindow.Level.normal + 1
+        let promptWindowLevel = PassthroughWindow.promptWindowLevel(above: hostWindowLevel)
+
+        XCTAssertGreaterThan(promptWindowLevel.rawValue, hostWindowLevel.rawValue)
+        XCTAssertLessThan(promptWindowLevel.rawValue, UIWindow.Level.alert.rawValue)
+    }
+
+    func testPromptWindowLevelStaysBelowAlertLevelWindows() {
+        let promptWindowLevel = PassthroughWindow.promptWindowLevel(above: .alert)
+
+        XCTAssertLessThan(promptWindowLevel.rawValue, UIWindow.Level.alert.rawValue)
+    }
+}


### PR DESCRIPTION
Fixes #123.

Survey prompts now appear above host app windows that use elevated window levels, while staying below alert-level windows.
