### PR TITLE
Add lifecycle event callbacks

### DIFF
--- a/Iterate.xcodeproj/project.pbxproj
+++ b/Iterate.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		270613CC23AD862C00DDF342 /* IterateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270613CB23AD862C00DDF342 /* IterateTests.swift */; };
 		270613CE23AD862C00DDF342 /* Iterate.h in Headers */ = {isa = PBXBuildFile; fileRef = 270613C023AD862C00DDF342 /* Iterate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		270613D823AD8D6200DDF342 /* Iterate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270613D723AD8D6200DDF342 /* Iterate.swift */; };
+		270613DA23AD8D6200DDF342 /* InteractionEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270613D923AD8D6200DDF342 /* InteractionEvents.swift */; };
 		270613DC23AE773500DDF342 /* ConfigureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270613DB23AE773500DDF342 /* ConfigureTests.swift */; };
 		270613DE23BA4A0900DDF342 /* SendEventIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270613DD23BA4A0900DDF342 /* SendEventIntegrationTests.swift */; };
 		270613E023BA4DD100DDF342 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270613DF23BA4DD100DDF342 /* Errors.swift */; };
@@ -87,6 +88,7 @@
 		270613CB23AD862C00DDF342 /* IterateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IterateTests.swift; sourceTree = "<group>"; };
 		270613CD23AD862C00DDF342 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		270613D723AD8D6200DDF342 /* Iterate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iterate.swift; sourceTree = "<group>"; };
+		270613D923AD8D6200DDF342 /* InteractionEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionEvents.swift; sourceTree = "<group>"; };
 		270613DB23AE773500DDF342 /* ConfigureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigureTests.swift; sourceTree = "<group>"; };
 		270613DD23BA4A0900DDF342 /* SendEventIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendEventIntegrationTests.swift; sourceTree = "<group>"; };
 		270613DF23BA4DD100DDF342 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
@@ -170,6 +172,7 @@
 			children = (
 				270613E923BA6B3D00DDF342 /* API */,
 				27C3B28323BA9D7E00754F4D /* Error */,
+				270613D523AD8D6200DDF342 /* Events */,
 				27821A3724900BE9004AAB22 /* Helpers */,
 				270613E123BA4EB600DDF342 /* SDK */,
 				27C3B29523BD352800754F4D /* Storage */,
@@ -197,6 +200,14 @@
 				270613D723AD8D6200DDF342 /* Iterate.swift */,
 			);
 			path = SDK;
+			sourceTree = "<group>";
+		};
+		270613D523AD8D6200DDF342 /* Events */ = {
+			isa = PBXGroup;
+			children = (
+				270613D923AD8D6200DDF342 /* InteractionEvents.swift */,
+			);
+			path = Events;
 			sourceTree = "<group>";
 		};
 		270613E923BA6B3D00DDF342 /* API */ = {
@@ -592,6 +603,7 @@
 				2C6163102C2F26BF00FD8317 /* Language.swift in Sources */,
 				27063AB024980D2B00BE6913 /* DisplayedEndpoint.swift in Sources */,
 				270613D823AD8D6200DDF342 /* Iterate.swift in Sources */,
+				270613DA23AD8D6200DDF342 /* InteractionEvents.swift in Sources */,
 				27C3B2EF23BFD44400754F4D /* PassthroughWindow.swift in Sources */,
 				2C0F0B0829BF8C3E000BD234 /* URL.swift in Sources */,
 			);

--- a/IterateSDK/API/Models/Survey.swift
+++ b/IterateSDK/API/Models/Survey.swift
@@ -13,7 +13,7 @@ public class Survey: Codable {
     let colorHex: String
     let colorDarkHex: String?
     let companyId: String
-    let id: String
+    public let id: String
     let primaryLanguage: String?
     let prompt: Prompt?
     let translations: [Translation]?

--- a/IterateSDK/Events/InteractionEvents.swift
+++ b/IterateSDK/Events/InteractionEvents.swift
@@ -1,0 +1,55 @@
+//
+//  InteractionEvents.swift
+//  Iterate
+//
+//  Created by Michael Singleton on 6/9/26.
+//  Copyright © 2026 Pickaxe LLC. (DBA Iterate). All rights reserved.
+//
+
+public enum InteractionEventType: String {
+    case dismiss
+    case displayed
+    case response
+    case surveyComplete = "survey-complete"
+}
+
+public enum InteractionEventSource: String {
+    case prompt
+    case survey
+}
+
+public struct InteractionEventQuestion {
+    public let id: String
+    public let prompt: String
+}
+
+public struct InteractionEventProgress {
+    public let completed: Int
+    public let total: Int
+    public let currentQuestion: InteractionEventQuestion?
+}
+
+public struct InteractionEvent {
+    public let type: InteractionEventType
+    public let survey: Survey
+    public let source: InteractionEventSource?
+    public let progress: InteractionEventProgress?
+    public let question: InteractionEventQuestion?
+    public let response: Any?
+
+    init(
+        type: InteractionEventType,
+        survey: Survey,
+        source: InteractionEventSource? = nil,
+        progress: InteractionEventProgress? = nil,
+        question: InteractionEventQuestion? = nil,
+        response: Any? = nil
+    ) {
+        self.type = type
+        self.survey = survey
+        self.source = source
+        self.progress = progress
+        self.question = question
+        self.response = response
+    }
+}

--- a/IterateSDK/SDK/Iterate.swift
+++ b/IterateSDK/SDK/Iterate.swift
@@ -46,6 +46,8 @@ public final class Iterate {
     
     /// Storage engine for storing user data like their API key and user attributes
     private var storage: StorageEngine
+
+    private var onEventCallback: ((InteractionEvent) -> Void)?
     
     /// Container manages the overlay window
     private let container = ContainerWindowDelegate()
@@ -165,6 +167,11 @@ public final class Iterate {
         return send(context: EmbedContext(self, withSurveyId: surveyId), complete: complete)
     }
     
+    /// Set a callback to observe survey interaction lifecycle events.
+    public func onEvent(_ callback: @escaping (InteractionEvent) -> Void) {
+        onEventCallback = callback
+    }
+
     /// Configure sets the necessary configuration properties. This should be called before any other methods.
     /// - Parameter apiKey: Your Iterate API Key, you can find this on your settings page
     public func configure(apiKey: String, apiHost: String? = Iterate.DefaultAPIHost, surveyTextFontName: String? = nil, buttonFontName: String? = nil) {
@@ -229,6 +236,10 @@ public final class Iterate {
         
         // Clear response properties
         responseProperties = nil
+    }
+
+    func dispatchInteractionEvent(_ event: InteractionEvent) {
+        onEventCallback?(event)
     }
     
     // MARK: Private methods

--- a/IterateSDK/SDK/UI/Container/Controllers/ContainerWindowDelegate.swift
+++ b/IterateSDK/SDK/UI/Container/Controllers/ContainerWindowDelegate.swift
@@ -52,6 +52,7 @@ final class ContainerWindowDelegate {
     func showPrompt(_ survey: Survey) {
         self.showWindow(survey: survey)
         self.containerViewController?.showPrompt()
+        Iterate.shared.dispatchInteractionEvent(InteractionEvent(type: .displayed, survey: survey, source: .prompt))
     }
         
     func showSurvey(_ survey: Survey) {
@@ -69,11 +70,13 @@ final class ContainerWindowDelegate {
         surveyViewController.survey = survey
         surveyViewController.delegate = self
         self.getPresentingViewController()?.present(surveyViewController, animated: true, completion: nil)
+        Iterate.shared.dispatchInteractionEvent(InteractionEvent(type: .displayed, survey: survey, source: .survey))
     }
     
     func dismissPrompt(survey: Survey?, userInitiated: Bool) {
         if let survey = survey, userInitiated {
             Iterate.shared.api?.dismissed(survey: survey, completion: { _, _ in })
+            Iterate.shared.dispatchInteractionEvent(InteractionEvent(type: .dismiss, survey: survey, source: .prompt))
         }
         
         containerViewController?.hidePrompt(complete: {
@@ -88,9 +91,10 @@ final class ContainerWindowDelegate {
     
     /// Called once a survey has been dismissed, this can happen if a user clicks the 'X' within a survey
     /// or drags down on the modal view
-    func surveyDismissed(survey: Survey?) {
+    func surveyDismissed(survey: Survey?, progress: InteractionEventProgress?) {
         if let survey = survey {
             Iterate.shared.api?.dismissed(survey: survey, completion: { _, _ in })
+            Iterate.shared.dispatchInteractionEvent(InteractionEvent(type: .dismiss, survey: survey, source: .survey, progress: progress))
         }
         
         self.containerViewController?.isSurveyDisplayed = false

--- a/IterateSDK/SDK/UI/Survey/Controllers/SurveyViewController.swift
+++ b/IterateSDK/SDK/UI/Survey/Controllers/SurveyViewController.swift
@@ -20,6 +20,7 @@ final class SurveyViewController: UIViewController {
     
     var delegate: ContainerWindowDelegate?
     var observation: NSKeyValueObservation?
+    private var progress: InteractionEventProgress?
     var survey: Survey? {
         willSet(newSurvey) {
             guard survey == nil else {
@@ -166,7 +167,7 @@ final class SurveyViewController: UIViewController {
     }
     
     override func viewDidDisappear(_ animated: Bool) {
-        delegate?.surveyDismissed(survey: survey)
+        delegate?.surveyDismissed(survey: survey, progress: progress)
     }
 }
 
@@ -174,12 +175,15 @@ final class SurveyViewController: UIViewController {
 
 private enum MessageType: String {
     case close = "close"
+    case progress = "progress"
+    case response = "response"
+    case surveyComplete = "survey-complete"
 }
 
 extension SurveyViewController: WKScriptMessageHandler {
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         if message.name == MessageHandlerName {
-            guard let body = message.body as? [String: AnyObject],
+            guard let body = message.body as? [String: Any],
                 let messageType = MessageType(rawValue:body["type"] as? String ?? "") else {
                 return
             }
@@ -187,8 +191,66 @@ extension SurveyViewController: WKScriptMessageHandler {
             switch messageType {
             case .close:
                 delegate?.dismissSurvey()
+            case .progress:
+                progress = InteractionEventProgress(data: body["data"])
+            case .response:
+                guard let survey = survey,
+                    let data = body["data"] as? [String: Any],
+                    let question = InteractionEventQuestion(data: data["question"]),
+                    let response = data["response"],
+                    !(response is NSNull) else {
+                    return
+                }
+
+                Iterate.shared.dispatchInteractionEvent(
+                    InteractionEvent(type: .response, survey: survey, question: question, response: response)
+                )
+            case .surveyComplete:
+                if let survey = survey {
+                    Iterate.shared.dispatchInteractionEvent(InteractionEvent(type: .surveyComplete, survey: survey))
+                }
             }
         }
+    }
+}
+
+private extension InteractionEventQuestion {
+    init?(data: Any?) {
+        guard let data = data as? [String: Any],
+            let id = data["id"] as? String,
+            let prompt = data["prompt"] as? String else {
+            return nil
+        }
+
+        self.init(id: id, prompt: prompt)
+    }
+}
+
+private extension InteractionEventProgress {
+    init?(data: Any?) {
+        guard let data = data as? [String: Any],
+            let completed = InteractionEventProgress.intValue(data["completed"]),
+            let total = InteractionEventProgress.intValue(data["total"]) else {
+            return nil
+        }
+
+        self.init(
+            completed: completed,
+            total: total,
+            currentQuestion: InteractionEventQuestion(data: data["currentQuestion"])
+        )
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        if let value = value as? Int {
+            return value
+        }
+
+        if let value = value as? NSNumber {
+            return value.intValue
+        }
+
+        return nil
     }
 }
 

--- a/IterateSDKTests/Unit/SDK/IterateTests.swift
+++ b/IterateSDKTests/Unit/SDK/IterateTests.swift
@@ -33,6 +33,27 @@ class IterateTests: XCTestCase {
         XCTAssertNoThrow(Iterate.shared)
     }
     
+    func testOnEventCallbackReceivesInteractionEvents() {
+        let client = Iterate(storage: MockStorageEngine())
+        let survey = Survey()
+        var receivedEvent: InteractionEvent?
+
+        client.onEvent { event in
+            receivedEvent = event
+        }
+
+        client.dispatchInteractionEvent(InteractionEvent(type: .displayed, survey: survey, source: .survey))
+
+        guard let event = receivedEvent else {
+            XCTFail("Expected onEvent callback to receive an event")
+            return
+        }
+
+        XCTAssertEqual(event.type, .displayed)
+        XCTAssertEqual(event.source, .survey)
+        XCTAssertTrue(event.survey === survey)
+    }
+
     /// Test that the company API key is correctly used when the user API key isn't present
     func testCompanyApiKeyUsed() {
         let client = Iterate(storage: MockStorageEngine())

--- a/README.md
+++ b/README.md
@@ -233,6 +233,27 @@ Once that's added you can scan the QR code on the "Preview & Publish" tab of you
 
 When implementing Iterate for the first time, we encourage you to implement events for _all_ of your core use cases which you may want to target surveys to in the future. e.g. signup, purchased, viewed X screen, tapped notification, etc. This way you can easily launch new surveys targeting these events without needing to instrument a new event each time.
 
+## Survey lifecycle events
+
+Use `onEvent` to observe survey interaction lifecycle events in your app.
+
+```swift
+Iterate.shared.onEvent { event in
+    switch event.type {
+    case .displayed:
+        // Prompt or survey displayed
+    case .dismiss:
+        // Prompt or survey dismissed
+    case .response:
+        // Question response submitted
+    case .surveyComplete:
+        // User reached the thank you screen
+    }
+}
+```
+
+Displayed and dismiss events include `event.source` (`.prompt` or `.survey`). Survey dismiss events may include `event.progress`, and response events include `event.question` and `event.response`.
+
 ## Custom fonts
 
 Custom fonts that are available in your app bundle can be used in the Iterate survey view by passing their names to the `Iterate.shared.configure` method, like this:


### PR DESCRIPTION
Adds an `onEvent` callback so apps can listen for displayed, dismiss, response, and survey-complete events while a survey is open.

Closes #125.