### PR TITLE
Version 1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 `iterate-ios` adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.6.4](https://github.com/iteratehq/iterate-ios/releases/tag/v1.6.4)
+
+Released 2026-06-10.
+
+**Added**
+
+- Added lifecycle event callbacks
+
+**Fixed**
+
+- Fixed an issue with the survey prompt window level
+
 ## [1.6.3](https://github.com/iteratehq/iterate-ios/releases/tag/v1.6.3)
 
 Released 2026-06-01.

--- a/Iterate.podspec
+++ b/Iterate.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name           = "Iterate"
-  spec.version        = "1.6.3"
+  spec.version        = "1.6.4"
   spec.summary        = "In-app user research made easy."
   spec.description    = <<-DESC
                         Iterate surveys put you directly in touch with your app users to 

--- a/IterateSDK/SDK/Iterate.swift
+++ b/IterateSDK/SDK/Iterate.swift
@@ -21,7 +21,7 @@ public final class Iterate {
     public static let PreviewParameter = "iterate_preview"
     
     // Current version number, will be updated on each release
-    static let Version = "1.6.3"
+    static let Version = "1.6.4"
     
     /// Default API host
     public static let DefaultAPIHost = "https://iteratehq.com"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Run surveys that are highly targeted, user-friendly, and on-brand. You’ll unde
 You can install Iterate using the [Carthage](https://github.com/Carthage/Carthage) dependency manager by installing Carthage and adding the following to your Cartfile:
 
 ```text
-github "iteratehq/iterate-ios" ~> 1.6.3
+github "iteratehq/iterate-ios" ~> 1.6.4
 ```
 
 Then run
@@ -47,7 +47,7 @@ and follow the Carthage [instructions](https://github.com/Carthage/Carthage#if-y
 You can install Iterate using the [CocoaPods](http://cocoapods.org/) dependency manager by installing CocoaPods and adding the following to your Podfile:
 
 ```ruby
-pod 'Iterate', '~> 1.6.3'
+pod 'Iterate', '~> 1.6.4'
 ```
 
 Then run


### PR DESCRIPTION
Release 1.6.4.

**Added**
- Added lifecycle event callbacks (#127)

**Fixed**
- Fixed an issue with the survey prompt window level (#126)

Version bumped in `Iterate.swift`, `Iterate.podspec`, and README installation instructions. `pod lib lint` passes. Tag `1.6.4` pushed.