### PR TITLE
Fix broken README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Iterate for iOS
 
-[![build](https://img.shields.io/travis/com/iteratehq/iterate-ios)](https://travis-ci.com/github/iteratehq/iterate-ios) [![version](https://img.shields.io/codeclimate/maintainability/iteratehq/iterate-ios)](https://codeclimate.com/github/iteratehq/iterate-ios) [![version](https://img.shields.io/github/v/tag/iteratehq/iterate-ios?label=version)](https://github.com/iteratehq/iterate-ios/releases) [![CocoaPod](https://img.shields.io/cocoapods/v/Iterate)](https://cocoapods.org/pods/Iterate) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) [![license](https://img.shields.io/github/license/iteratehq/iterate-ios?color=%23000000)](https://github.com/iteratehq/iterate-ios/blob/main/LICENSE.txt)
+[![build](https://github.com/iteratehq/iterate-ios/actions/workflows/ci.yml/badge.svg)](https://github.com/iteratehq/iterate-ios/actions/workflows/ci.yml) [![version](https://img.shields.io/github/v/tag/iteratehq/iterate-ios?label=version)](https://github.com/iteratehq/iterate-ios/releases) [![CocoaPod](https://img.shields.io/cocoapods/v/Iterate)](https://cocoapods.org/pods/Iterate) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) [![license](https://img.shields.io/github/license/iteratehq/iterate-ios?color=%23000000)](https://github.com/iteratehq/iterate-ios/blob/main/LICENSE.txt)
 
 ---
 


### PR DESCRIPTION
The two left-most README badges were broken:

- **Build badge** pointed at Travis CI, which is no longer used (CI moved to GitHub Actions in #124). Replaced it with the GitHub Actions `CI` workflow status badge.
- **Code Climate** maintainability badge is a retired shields.io badge (rendered as "retired badge") and the repo isn't wired to Code Climate. It was also mislabeled `version` (there's already a real version badge right after it). Removed it.

Remaining badges (version, CocoaPods, Carthage, license) are unchanged and working.

Note: `.travis.yml` is now unused and could be removed in a follow-up.